### PR TITLE
Added support question link for issue reporting options

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Support Question
+    url: https://github.com/oerdnj/deb.sury.org/discussions
+    about: Get community support through GitHub Discussions.


### PR DESCRIPTION
# Background
As I new user, I came to this repository to ask a question. I accidentally opened an issue instead of seeing "Discussions" at the top. 

# Problem
- New users may have the habit of opening issues instead of looking for "discussions"
- This adds extra work for @oerdnj to keep things organized

# Proposed Solution (what this PR does)
- It adds a extra button on the issue reporting to help guide users to "Discussions" for support questions

# Demo
![image](https://user-images.githubusercontent.com/3174134/193065463-f0c534ed-7bc6-4c15-b07f-e9986a343e44.png)

You can view my fork for exact results: https://github.com/jaydrogers/deb.sury.org/issues/new/choose

Thanks for your hard work! Hope you find this helpful 👍